### PR TITLE
Add conan support

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,31 @@
+from conans import ConanFile, CMake
+import os
+
+
+class OutcomeConan(ConanFile):
+    name = "outcome"
+    version = "master"
+    license = "Apache-2.0"
+    description = "Provides very lightweight outcome<T> and result<T>"
+    url = "https://github.com/ned14/outcome"
+    settings = "os", "compiler", "arch", "build_type"
+    generators = "cmake"
+
+    @property
+    def outcome_src(self):
+        return os.path.join(self.source_folder, self.name)
+
+    def source(self):
+        self.run("git clone %s --branch %s" % (self.url, self.version))
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(source_dir=self.outcome_src, build_dir="build")
+        cmake.build()
+        cmake.test()
+
+    def package(self):
+        self.copy("outcome.hpp", dst="include", src=os.path.join("outcome", "single-header"))
+
+    def package_id(self):
+        self.info.header_only()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,31 +1,19 @@
-from conans import ConanFile, CMake
-import os
-
+from conans import ConanFile, tools
 
 class OutcomeConan(ConanFile):
     name = "outcome"
     version = "master"
     license = "Apache-2.0"
     description = "Provides very lightweight outcome<T> and result<T>"
-    url = "https://github.com/ned14/outcome"
-    settings = "os", "compiler", "arch", "build_type"
-    generators = "cmake"
-
-    @property
-    def outcome_src(self):
-        return os.path.join(self.source_folder, self.name)
+    repo_url = "https://github.com/ned14/outcome"
+    build_policy = "always"
 
     def source(self):
-        self.run("git clone %s --branch %s" % (self.url, self.version))
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure(source_dir=self.outcome_src, build_dir="build")
-        cmake.build()
-        cmake.test()
+        file_url = "https://raw.githubusercontent.com/ned14/outcome/master/single-header/outcome.hpp"
+        tools.download(file_url, filename="outcome.hpp")
 
     def package(self):
-        self.copy("outcome.hpp", dst="include", src=os.path.join("outcome", "single-header"))
+        self.copy("outcome.hpp", dst="include")
 
     def package_id(self):
         self.info.header_only()

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(OutcomePackageTest CXX)
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_executable(example example.cpp)
+target_link_libraries(example CONAN_PKG::outcome)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,16 @@
+from conans import ConanFile, CMake
+import os
+
+class OutcomeTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
+        cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
+        cmake.build()
+
+    def test(self):
+        os.chdir("bin")
+        self.run(".%sexample" % os.sep)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <string>
+
+#include <outcome.hpp>
+
+namespace outcome = OUTCOME_V2_NAMESPACE;
+
+outcome::result<std::string> hello()
+{
+  return "Hello, World!";
+}
+
+int main()
+{
+  std::cout << hello() << std::endl;
+}


### PR DESCRIPTION
Hi!

I've added basic Conan support for Outcome, there are some issues left:

* Do we want to build unit tests inconditionally? (gcc 7.2 crashed on my Debian)
* I'm only packaging the single-header, since QuickCppLib is not installed by `ninja install`.

I didn't want to change the `CMakeLists.txt` before having your feedback, let me know if you want to support more than the single-header.