### PR TITLE
Fix typos

### DIFF
--- a/doc/src/content/tutorial/payload/_index.md
+++ b/doc/src/content/tutorial/payload/_index.md
@@ -6,7 +6,7 @@ tags = [ "payload", "has_error_code", "make_error_code" ]
 +++
 
 So far in this tutorial, type `EC` in `result<T, EC>` has always been a
-`std::error_code` (though it can be of any type you wish instead). `EC` need
+`std::error_code` (though it can be of any type you wish instead). `EC` needs
 in fact to merely satisfy
 {{< api "success_failure/#standardese-outcome_v2_xxx__trait__has_error_code-T-" "trait::has_error_code_v<EC>">}}
 for `EC` to be treated as if an `std::error_code`.

--- a/doc/src/content/tutorial/result/inspecting.md
+++ b/doc/src/content/tutorial/result/inspecting.md
@@ -11,7 +11,7 @@ Suppose we will be writing a function `print_half` that takes an integer number 
 
 The type `result<void>` means that there is no value to be retuned upon success, but that the operation might still fail, and we may be interested in inspecting the cause of the failure. The class template `result<>` is declared with the attribute `[[nodiscard]]`, which means the compiler will warn you if you forget to inspect the returned object (in C++ 17 or later).
 
-The implementation will do the following: if the integral number can be represnted by an `int`, we will convert to `int` and use its arithmetical operations. If the number is too large, we will fall back to using a custom `BigInt` implementation that needs to allocate memory. In the implementation we will use the function `convert` defined in the previous section.
+The implementation will do the following: if the integral number can be represented by an `int`, we will convert to `int` and use its arithmetical operations. If the number is too large, we will fall back to using a custom `BigInt` implementation that needs to allocate memory. In the implementation we will use the function `convert` defined in the previous section.
 
 {{% snippet "using_result.cpp" "half_impl" %}}
 

--- a/doc/src/snippets/using_result.cpp
+++ b/doc/src/snippets/using_result.cpp
@@ -116,14 +116,14 @@ outcome::result<void> print_half(const std::string& text)
 {
   if (outcome::result<int> r = convert(text))     // #1
   {
-    std::cout << (r.value() / 2) << std::endl;    // #2
+    std::cout << (r.value() / 2) << '\n';    // #2
   }
   else
   {
     if (r.error() == ConversionErrc::TooLong)     // #3 
     {
       OUTCOME_TRY (i, BigInt::fromString(text));  // #4
-      std::cout << i.half() << std::endl;
+      std::cout << i.half() << '\n';
     }
     else
     {
@@ -148,11 +148,11 @@ int main()
 {
   if (outcome::result<void> r = print_half("1299999999999999999999999999"))
   {
-    std::cout << "ok" << std::endl;
+    std::cout << "ok" << '\n';
   }
   else
   {
-    std::cout << r.error() << std::endl; 
+    std::cout << r.error() << '\n'; 
   }
   
   (void)test();


### PR DESCRIPTION
Hi,
Thanks for this great library.
I am reading the documentation and fixed some typos in a first commit.
A second commit is for replacing std::endl by '\n' because I keep seing everywhere that we should avoid it (not sure you want to merge it)