### PR TITLE
Fix line height so it doesn't eat underscores

### DIFF
--- a/doc/src/static/css/local.css
+++ b/doc/src/static/css/local.css
@@ -11,6 +11,7 @@ h2 {
 code, pre {
   background: none;
   border: none;
+  line-height: 1.5;
   text-align: left;
 }
 a code {


### PR DESCRIPTION
Set line-height for pre to 1.5. Line height given by master.scss for pre is set to 1.15. This causes the top of the line below to blank out underscores making them look like spaces