### PR TITLE
Fix compilation on Android

### DIFF
--- a/single-header/outcome-experimental.hpp
+++ b/single-header/outcome-experimental.hpp
@@ -7867,7 +7867,7 @@ class _posix_code_domain : public status_code_domain
     char buffer[1024] = "";
 #ifdef _WIN32
     strerror_s(buffer, sizeof(buffer), c);
-#elif defined(__linux__)
+#elif defined(__gnu_linux__)
     char *s = strerror_r(c, buffer, sizeof(buffer));  // NOLINT
     if(s != nullptr)
     {

--- a/single-header/outcome-experimental.hpp
+++ b/single-header/outcome-experimental.hpp
@@ -7867,7 +7867,7 @@ class _posix_code_domain : public status_code_domain
     char buffer[1024] = "";
 #ifdef _WIN32
     strerror_s(buffer, sizeof(buffer), c);
-#elif defined(__gnu_linux__)
+#elif defined(__gnu_linux__) && ! defined(__ANDROID__)
     char *s = strerror_r(c, buffer, sizeof(buffer));  // NOLINT
     if(s != nullptr)
     {


### PR DESCRIPTION
strerror_r is GNU specific, use __\_\_gnu_linux\_\___ to guard GNU specific functions.
Also, there is a [bug in Android NDK](https://github.com/android-ndk/ndk/issues/874), so additional check for __\_\_ANDROID\_\___ is needed.