### PR TITLE
Fix Boost.System trait namespacing

### DIFF
--- a/doc/src/content/reference/functions/policy/outcome_throw_as_system_error_with_payload_boost_enum.md
+++ b/doc/src/content/reference/functions/policy/outcome_throw_as_system_error_with_payload_boost_enum.md
@@ -1,13 +1,13 @@
 +++
 title = "`void outcome_throw_as_system_error_with_payload(BoostErrorCodeEnum &&)`"
-description = "Specialisation of `outcome_throw_as_system_error_with_payload()` for input types where `boost::system::errc::is_error_code_enum<BoostErrorCodeEnum>` or `boost::system::errc::is_error_condition_enum<BoostErrorCodeEnum>` is true."
+description = "Specialisation of `outcome_throw_as_system_error_with_payload()` for input types where `boost::system::is_error_code_enum<BoostErrorCodeEnum>` or `boost::system::is_error_condition_enum<BoostErrorCodeEnum>` is true."
 +++
 
-A specialisation of `outcome_throw_as_system_error_with_payload()` for types where `boost::system::errc::is_error_code_enum<BoostErrorCodeEnum>` or `boost::system::errc::is_error_condition_enum<BoostErrorCodeEnum>` is true. This executes {{% api "OUTCOME_THROW_EXCEPTION(expr)" %}} with a `boost::system::system_error` constructed from the result of the ADL discovered free function `make_error_code(BoostErrorCodeEnum)`.
+A specialisation of `outcome_throw_as_system_error_with_payload()` for types where `boost::system::is_error_code_enum<BoostErrorCodeEnum>` or `boost::system::is_error_condition_enum<BoostErrorCodeEnum>` is true. This executes {{% api "OUTCOME_THROW_EXCEPTION(expr)" %}} with a `boost::system::system_error` constructed from the result of the ADL discovered free function `make_error_code(BoostErrorCodeEnum)`.
 
 *Overridable*: Argument dependent lookup.
 
-*Requires*: Either `boost::system::errc::is_error_code_enum<T>` or `boost::system::errc::is_error_condition_enum<T>` to be true for a decayed `BoostErrorCodeEnum`.
+*Requires*: Either `boost::system::is_error_code_enum<T>` or `boost::system::is_error_condition_enum<T>` to be true for a decayed `BoostErrorCodeEnum`.
 
 *Namespace*: `boost::system`
 


### PR DESCRIPTION
I noticed that the [`outcome_throw_as_system_error_with_payload(BoostErrorCodeEnum &&)`](https://ned14.github.io/outcome/reference/functions/policy/outcome_throw_as_system_error_with_payload_boost_enum/) page refers to the trait class `boost::system::errc::is_error_meow_enum<BoostErrorCodeEnum>`. As per the [Boost.System docs](https://www.boost.org/doc/libs/1_70_0/libs/system/doc/html/system.html#ref_boostsystemerror_code_hpp) the trait is spelled `boost::system::is_error_meow_enum` (no `errc` namespace). 

Happily this error does not appear to be reproduced anywhere in the actual code:
- [`error_code_registration.cpp`](doc/src/snippets/boost-only/error_code_registration.cpp) puts the specialization in `boost::system`
- [`boost_result.hpp`](https://github.com/ned14/outcome/blob/develop/include/outcome/boost_result.hpp#L69) just opens the namespace `boost::system::errc` so that (if I follow) ADL allows calling `outcome_throw_as_system_error_with_payload(boost::system::errc::errc_t)`.