### PR TITLE
Add missing bad_outcome_access when throwing exception in experimental

### DIFF
--- a/include/outcome/experimental/status_outcome.hpp
+++ b/include/outcome/experimental/status_outcome.hpp
@@ -90,7 +90,7 @@ SIGNATURE NOT RECOGNISED
 #ifdef __cpp_exceptions
             base::_error(static_cast<Impl &&>(self)).throw_exception();
 #else
-            OUTCOME_THROW_EXCEPTION("wide value check failed");
+            OUTCOME_THROW_EXCEPTION(bad_outcome_access("wide value check failed"));
 #endif
           }
         }

--- a/include/outcome/experimental/status_result.hpp
+++ b/include/outcome/experimental/status_result.hpp
@@ -111,7 +111,7 @@ namespace experimental
 #ifdef __cpp_exceptions
             base::_error(static_cast<Impl &&>(self)).throw_exception();
 #else
-            OUTCOME_THROW_EXCEPTION("wide value check failed");
+            OUTCOME_THROW_EXCEPTION(bad_outcome_access("wide value check failed"));
 #endif
           }
         }


### PR DESCRIPTION
This adds the missing exception instantiation in the call to OUTCOME_THROW_EXCEPTION.

Issue: #234 