### PR TITLE
Use __cpp_concepts feature test macro

### DIFF
--- a/include/outcome/convert.hpp
+++ b/include/outcome/convert.hpp
@@ -32,7 +32,7 @@ OUTCOME_V2_NAMESPACE_EXPORT_BEGIN
 namespace concepts
 {
 #if defined(__cpp_concepts)
-#if !defined(_MSC_VER) && !defined(__clang__) && (__GNUC__ < 9 || __cplusplus < 202000L)
+#if !defined(_MSC_VER) && !defined(__clang__) && (__GNUC__ < 9 || __cpp_concepts < 201907L)
 #define OUTCOME_GCC6_CONCEPT_BOOL bool
 #else
 #define OUTCOME_GCC6_CONCEPT_BOOL


### PR DESCRIPTION
to decide on concepts syntax.

With gcc 10.2 -std=c++20, which uses the C++20 Standard concepts syntax, __cplusplus = 201709L whereas __cpp_concepts = 201907L (the C++20 value).

after 5d63e610aeefb67f96ef9dec622f178c77e5fa3f