### PR TITLE
Fix inclusion of system provided status code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,17 +40,6 @@ include(QuickCppLibRequireOutOfSourceBuild)
 include(QuickCppLibUtils)
 include(QuickCppLibPolicies)
 
-if(OUTCOME_BUNDLE_EMBEDDED_STATUS_CODE)
-  ensure_git_subrepo("${CMAKE_CURRENT_SOURCE_DIR}/include/outcome/experimental/status-code/include" "https://github.com/ned14/status-code.git")
-else()
-  find_quickcpplib_library(status-code
-    GIT_REPOSITORY "https://github.com/ned14/status-code.git"
-    GIT_TAG "${OUTCOME_DEPENDENCY_STATUS_CODE_GIT_TAG}"
-    REQUIRED
-    IS_HEADER_ONLY
-  )
-endif()
-
 # Parse the version we tell cmake directly from the version header file
 ParseProjectVersionFromHpp("${CMAKE_CURRENT_SOURCE_DIR}/include/outcome/detail/version.hpp" VERSIONSTRING)
 # Sets the usual PROJECT_NAME etc
@@ -99,8 +88,16 @@ else()
     IS_HEADER_ONLY
   )
 endif()
-if (NOT OUTCOME_BUNDLE_EMBEDDED_STATUS_CODE)
-  list_filter(${PROJECT_NAME}_HEADERS EXCLUDE REGEX /status-code/include/)
+if(OUTCOME_BUNDLE_EMBEDDED_STATUS_CODE)
+  ensure_git_subrepo("${CMAKE_CURRENT_SOURCE_DIR}/include/outcome/experimental/status-code/include" "https://github.com/ned14/status-code.git")
+else()
+  find_quickcpplib_library(status-code
+    GIT_REPOSITORY "https://github.com/ned14/status-code.git"
+    GIT_TAG "${OUTCOME_DEPENDENCY_STATUS_CODE_GIT_TAG}"
+    REQUIRED
+    IS_HEADER_ONLY
+  )
+  list_filter(${PROJECT_NAME}_HEADERS EXCLUDE REGEX include/outcome/experimental/status-code/)
 endif()
 
 # Make an interface only library so dependent CMakeLists can bring in this header-only library

--- a/include/outcome/experimental/coroutine_support.hpp
+++ b/include/outcome/experimental/coroutine_support.hpp
@@ -45,7 +45,11 @@ Distributed under the Boost Software License, Version 1.0.
   OUTCOME_V2_NAMESPACE_END
 
 #ifdef __cpp_exceptions
+#if !OUTCOME_USE_SYSTEM_STATUS_CODE && __has_include("status-code/include/status-code/system_code_from_exception.hpp")
 #include "status-code/include/status-code/system_code_from_exception.hpp"
+#else
+#include <status-code/system_code_from_exception.hpp>
+#endif
 OUTCOME_V2_NAMESPACE_BEGIN
 namespace awaitables
 {


### PR DESCRIPTION
These popped up while intergrating with vcpkg, see commit messages. Fixes #268 