### PR TITLE
Use std::addressof instead of operator&

### DIFF
--- a/include/outcome/detail/value_storage.hpp
+++ b/include/outcome/detail/value_storage.hpp
@@ -1055,11 +1055,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
+        new(std::addressof(_value)) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
+        new(std::addressof(_error)) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
       }
       _status = o._status;
       o._status.set_have_moved_from(true);
@@ -1072,11 +1072,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_(o._value);  // NOLINT
+        new(std::addressof(_value)) _value_type_(o._value);  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_(o._error);  // NOLINT
+        new(std::addressof(_error)) _error_type_(o._error);  // NOLINT
       }
       _status = o._status;
     }
@@ -1182,11 +1182,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_();  // NOLINT
+        new(std::addressof(_value)) _value_type_();  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_(o._error);  // NOLINT
+        new(std::addressof(_error)) _error_type_(o._error);  // NOLINT
       }
       _status = o._status;
     }
@@ -1197,11 +1197,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_();  // NOLINT
+        new(std::addressof(_value)) _value_type_();  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
+        new(std::addressof(_error)) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
       }
       _status = o._status;
       o._status.set_have_moved_from(true);
@@ -1219,11 +1219,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_(o._value);  // NOLINT
+        new(std::addressof(_value)) _value_type_(o._value);  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_();  // NOLINT
+        new(std::addressof(_error)) _error_type_();  // NOLINT
       }
       _status = o._status;
     }
@@ -1234,11 +1234,11 @@ namespace detail
     {
       if(o._status.have_value())
       {
-        new(&_value) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
+        new(std::addressof(_value)) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
       }
       else if(o._status.have_error())
       {
-        new(&_error) _error_type_();  // NOLINT
+        new(std::addressof(_error)) _error_type_();  // NOLINT
       }
       _status = o._status;
       o._status.set_have_moved_from(true);
@@ -1325,7 +1325,7 @@ namespace detail
       if(_status.have_value() && !o._status.have_error())
       {
         // Move construct me into other
-        new(&o._value) _value_type_(static_cast<_value_type_ &&>(_value));  // NOLINT
+        new(std::addressof(o._value)) _value_type_(static_cast<_value_type_ &&>(_value));  // NOLINT
         if(!trait::is_move_bitcopying<value_type>::value)
         {
           this->_value.~value_type();  // NOLINT
@@ -1336,7 +1336,7 @@ namespace detail
       if(o._status.have_value() && !_status.have_error())
       {
         // Move construct other into me
-        new(&_value) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
+        new(std::addressof(_value)) _value_type_(static_cast<_value_type_ &&>(o._value));  // NOLINT
         if(!trait::is_move_bitcopying<value_type>::value)
         {
           o._value.~value_type();  // NOLINT
@@ -1347,7 +1347,7 @@ namespace detail
       if(_status.have_error() && !o._status.have_value())
       {
         // Move construct me into other
-        new(&o._error) _error_type_(static_cast<_error_type_ &&>(_error));  // NOLINT
+        new(std::addressof(o._error)) _error_type_(static_cast<_error_type_ &&>(_error));  // NOLINT
         if(!trait::is_move_bitcopying<error_type>::value)
         {
           this->_error.~error_type();  // NOLINT
@@ -1358,7 +1358,7 @@ namespace detail
       if(o._status.have_error() && !_status.have_value())
       {
         // Move construct other into me
-        new(&_error) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
+        new(std::addressof(_error)) _error_type_(static_cast<_error_type_ &&>(o._error));  // NOLINT
         if(!trait::is_move_bitcopying<error_type>::value)
         {
           o._error.~error_type();  // NOLINT
@@ -1382,7 +1382,7 @@ namespace detail
             this->b.set_have_lost_consistency(true);
           }
         }
-      } _{_status, o._status, &_value, &o._value, &_error, &o._error};
+      } _{_status, o._status, std::addressof(_value), std::addressof(o._value), std::addressof(_error), std::addressof(o._error)};
       if(_status.have_value() && o._status.have_error())
       {
         strong_placement(_.all_good, _.o_value, _.value, [&_] {    //
@@ -1507,7 +1507,7 @@ namespace detail
       }
       if(!this->_status.have_value() && !this->_status.have_error() && o._status.have_value())
       {
-        move_assign_to_empty<_value_type_>(&this->_value, &o._value);
+        move_assign_to_empty<_value_type_>(std::addressof(this->_value), std::addressof(o._value));
         this->_status = o._status;
         o._status.set_have_moved_from(true);
         return *this;
@@ -1524,7 +1524,7 @@ namespace detail
       }
       if(!this->_status.have_value() && !this->_status.have_error() && o._status.have_error())
       {
-        move_assign_to_empty<_error_type_>(&this->_error, &o._error);
+        move_assign_to_empty<_error_type_>(std::addressof(this->_error), std::addressof(o._error));
         this->_status = o._status;
         o._status.set_have_moved_from(true);
         return *this;
@@ -1535,7 +1535,7 @@ namespace detail
         {
           this->_value.~_value_type_();  // NOLINT
         }
-        move_assign_to_empty<_error_type_>(&this->_error, &o._error);
+        move_assign_to_empty<_error_type_>(std::addressof(this->_error), std::addressof(o._error));
         this->_status = o._status;
         o._status.set_have_moved_from(true);
         return *this;
@@ -1546,7 +1546,7 @@ namespace detail
         {
           this->_error.~_error_type_();  // NOLINT
         }
-        move_assign_to_empty<_value_type_>(&this->_value, &o._value);
+        move_assign_to_empty<_value_type_>(std::addressof(this->_value), std::addressof(o._value));
         this->_status = o._status;
         o._status.set_have_moved_from(true);
         return *this;
@@ -1604,7 +1604,7 @@ namespace detail
       }
       if(!this->_status.have_value() && !this->_status.have_error() && o._status.have_value())
       {
-        copy_assign_to_empty<_value_type_>(&this->_value, &o._value);
+        copy_assign_to_empty<_value_type_>(std::addressof(this->_value), std::addressof(o._value));
         this->_status = o._status;
         return *this;
       }
@@ -1619,7 +1619,7 @@ namespace detail
       }
       if(!this->_status.have_value() && !this->_status.have_error() && o._status.have_error())
       {
-        copy_assign_to_empty<_error_type_>(&this->_error, &o._error);
+        copy_assign_to_empty<_error_type_>(std::addressof(this->_error), std::addressof(o._error));
         this->_status = o._status;
         return *this;
       }
@@ -1629,7 +1629,7 @@ namespace detail
         {
           this->_value.~_value_type_();  // NOLINT
         }
-        copy_assign_to_empty<_error_type_>(&this->_error, &o._error);
+        copy_assign_to_empty<_error_type_>(std::addressof(this->_error), std::addressof(o._error));
         this->_status = o._status;
         return *this;
       }
@@ -1639,7 +1639,7 @@ namespace detail
         {
           this->_error.~_error_type_();  // NOLINT
         }
-        copy_assign_to_empty<_value_type_>(&this->_value, &o._value);
+        copy_assign_to_empty<_value_type_>(std::addressof(this->_value), std::addressof(o._value));
         this->_status = o._status;
         return *this;
       }

--- a/include/outcome/iostream_support.hpp
+++ b/include/outcome/iostream_support.hpp
@@ -82,13 +82,13 @@ namespace detail
     v._status.spare_storage_value = y;
     if(v._status.have_value())
     {
-      new(&v._value) decltype(v._value)();  // NOLINT
-      s >> v._value;                        // NOLINT
+      new(std::addressof(v._value)) decltype(v._value)();  // NOLINT
+      s >> v._value;                                       // NOLINT
     }
     if(v._status.have_error())
     {
-      new(&v._error) decltype(v._error)();  // NOLINT
-      s >> v._error;                        // NOLINT
+      new(std::addressof(v._error)) decltype(v._error)();  // NOLINT
+      s >> v._error;                                       // NOLINT
     }
     return s;
   }
@@ -103,8 +103,8 @@ namespace detail
     v._status.spare_storage_value = y;
     if(v._status.have_error())
     {
-      new(&v._error) decltype(v._error)();  // NOLINT
-      s >> v._error;                        // NOLINT
+      new(std::addressof(v._error)) decltype(v._error)();  // NOLINT
+      s >> v._error;                                       // NOLINT
     }
     return s;
   }
@@ -119,8 +119,8 @@ namespace detail
     v._status.spare_storage_value = y;
     if(v._status.have_value())
     {
-      new(&v._value) decltype(v._value)();  // NOLINT
-      s >> v._value;                        // NOLINT
+      new(std::addressof(v._value)) decltype(v._value)();  // NOLINT
+      s >> v._value;                                       // NOLINT
     }
     return s;
   }


### PR DESCRIPTION
Noticed this while using [wil](https://github.com/microsoft/wil), where some wrappers have custom `operator&` (e.g. `HANDLE* unique_process_handle::operator&`).

I didn't add tests for the iostream stuff since it seems broken (a contained error is written twice, once via state and a second time explicitly) and somehow excludes `void` value/error types (even though the implementation has `void`-overloads).