### PR TITLE
Work around msvc bug

### DIFF
--- a/include/outcome/basic_result.hpp
+++ b/include/outcome/basic_result.hpp
@@ -440,7 +440,7 @@ SIGNATURE NOT RECOGNISED
 SIGNATURE NOT RECOGNISED
 */
   OUTCOME_TEMPLATE(class ErrorCondEnum)
-  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(ErrorCondEnum()))),  //
+  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(std::declval<ErrorCondEnum>()))),  //
                     OUTCOME_TPRED(predicate::template enable_error_condition_converting_constructor<ErrorCondEnum>))
   constexpr basic_result(ErrorCondEnum &&t, error_condition_converting_constructor_tag /*unused*/ = error_condition_converting_constructor_tag()) noexcept(
   noexcept(error_type(make_error_code(static_cast<ErrorCondEnum &&>(t)))))  // NOLINT

--- a/single-header/outcome-basic.hpp
+++ b/single-header/outcome-basic.hpp
@@ -4711,7 +4711,7 @@ SIGNATURE NOT RECOGNISED
 SIGNATURE NOT RECOGNISED
 */
   OUTCOME_TEMPLATE(class ErrorCondEnum)
-  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(ErrorCondEnum()))), //
+  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(std::declval<ErrorCondEnum>()))), //
                     OUTCOME_TPRED(predicate::template enable_error_condition_converting_constructor<ErrorCondEnum>))
   constexpr basic_result(ErrorCondEnum &&t, error_condition_converting_constructor_tag /*unused*/ = error_condition_converting_constructor_tag()) noexcept(
   noexcept(error_type(make_error_code(static_cast<ErrorCondEnum &&>(t))))) // NOLINT

--- a/single-header/outcome-experimental.hpp
+++ b/single-header/outcome-experimental.hpp
@@ -4736,7 +4736,7 @@ SIGNATURE NOT RECOGNISED
 SIGNATURE NOT RECOGNISED
 */
   OUTCOME_TEMPLATE(class ErrorCondEnum)
-  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(ErrorCondEnum()))), //
+  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(std::declval<ErrorCondEnum>()))), //
                     OUTCOME_TPRED(predicate::template enable_error_condition_converting_constructor<ErrorCondEnum>))
   constexpr basic_result(ErrorCondEnum &&t, error_condition_converting_constructor_tag /*unused*/ = error_condition_converting_constructor_tag()) noexcept(
   noexcept(error_type(make_error_code(static_cast<ErrorCondEnum &&>(t))))) // NOLINT

--- a/single-header/outcome.hpp
+++ b/single-header/outcome.hpp
@@ -5648,7 +5648,7 @@ SIGNATURE NOT RECOGNISED
 SIGNATURE NOT RECOGNISED
 */
   OUTCOME_TEMPLATE(class ErrorCondEnum)
-  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(ErrorCondEnum()))), //
+  OUTCOME_TREQUIRES(OUTCOME_TEXPR(error_type(make_error_code(std::declval<ErrorCondEnum>()))), //
                     OUTCOME_TPRED(predicate::template enable_error_condition_converting_constructor<ErrorCondEnum>))
   constexpr basic_result(ErrorCondEnum &&t, error_condition_converting_constructor_tag /*unused*/ = error_condition_converting_constructor_tag()) noexcept(
   noexcept(error_type(make_error_code(static_cast<ErrorCondEnum &&>(t))))) // NOLINT


### PR DESCRIPTION
Outcome triggers [a SFINAE bug in MSVC](https://developercommunity.visualstudio.com/t/Bogus-error-when-using-SFINAE-with-an-ov/10752128) by attempting to default construct `ErrorCondEnum` in a type constraint. This patch works around it by using `std::declval` instead.

Reproduction source file (also [on godbolt](https://godbolt.org/z/94aEdds53))
```cpp
#include <outcome.hpp>

struct inner {
	explicit inner(int);
	inner(inner &&);
};
struct middle {
	inner inn;
	template <class... Args>
	explicit middle(Args &&...args) : inn(static_cast<Args &&>(args)...) {}
	middle(middle &&);
};
struct outer {
	middle mid;
	int i = 0;
};

namespace o = OUTCOME_V2_NAMESPACE;

o::result<outer> func(outer &&out) {
	return static_cast<outer &&>(out);
}
```