### PR TITLE
Fix breakage of 32-bit ARM build.

### DIFF
--- a/include/outcome/outcome_gdb.h
+++ b/include/outcome/outcome_gdb.h
@@ -32,7 +32,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.OUTCOME_INLINE_GDB_PRETTY_PRINTER_H\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
         ".ascii \"import os\\n\"\n"

--- a/single-header/outcome-basic.hpp
+++ b/single-header/outcome-basic.hpp
@@ -3932,7 +3932,7 @@ OUTCOME_V2_NAMESPACE_END
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.OUTCOME_INLINE_GDB_PRETTY_PRINTER_H\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
         ".ascii \"import os\\n\"\n"

--- a/single-header/outcome-experimental.hpp
+++ b/single-header/outcome-experimental.hpp
@@ -3957,7 +3957,7 @@ OUTCOME_V2_NAMESPACE_END
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.OUTCOME_INLINE_GDB_PRETTY_PRINTER_H\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
         ".ascii \"import os\\n\"\n"
@@ -8132,7 +8132,7 @@ SYSTEM_ERROR2_NAMESPACE_END
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
 __asm__(
-".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
 ".ascii \"\\4gdb.inlined-script.SYSTEM_ERROR2_INLINE_GDB_PRETTY_PRINTERS_H\\n\"\n"
 ".ascii \"import gdb.printing\\n\"\n"
 ".ascii \"import gdb\\n\"\n"

--- a/single-header/outcome.hpp
+++ b/single-header/outcome.hpp
@@ -4869,7 +4869,7 @@ OUTCOME_V2_NAMESPACE_END
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Woverlength-strings"
 #endif
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.OUTCOME_INLINE_GDB_PRETTY_PRINTER_H\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
         ".ascii \"import os\\n\"\n"


### PR DESCRIPTION
While some platforms support @progbits with a @, as far as I can tell all support it with %. Notably, 32-bit ARM (armeabi-v7a for Android, in my case) seems to not support the @.

```
<inline asm>:1:41: error: expected '%<type>' or "<type>"
    1 | .pushsection ".debug_gdb_scripts", "MS",@progbits,1
      |                                         ^
<inline asm>:101:12: error: .popsection without corresponding .pushsection
  101 | .popsection
      |            ^
2 errors generated.
```

This is (I presume) the actual underlying cause of the Android issue that was fixed in ebcd26750db46336e460d5e5de9448474a25854e, but it doesn't only affect Android: I'm also getting this when trying to compile for 32-bit ARM desktop Linux systems. I've thereby also removed the new !__ANDROID__ ifdef as part of this fix.